### PR TITLE
Hard-code versions of build dependencies

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -80,6 +80,8 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.cibw-archs }}
           CIBW_SKIP: pp* cp313-* *-musllinux*
+          CIBW_DEPENDENCY_VERSIONS: pinned
+          CIBW_BUILD_VERBOSITY: 1
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment-target }}
         run: python -m cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -79,9 +79,8 @@ jobs:
       - name: Build wheels
         env:
           CIBW_ARCHS: ${{ matrix.cibw-archs }}
-          CIBW_SKIP: pp* cp313-* *-musllinux*
-          CIBW_DEPENDENCY_VERSIONS: pinned
           CIBW_BUILD_VERBOSITY: 1
+          CIBW_SKIP: pp* cp313-* *-musllinux*
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment-target }}
         run: python -m cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # These are the assumed default build requirements from pip:
 # https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
-requires = ["setuptools>=58,<74", "wheel"]
+requires = ["setuptools==73.0.1", "wheel==0.44.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # These are the assumed default build requirements from pip:
 # https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
-requires = ["setuptools>=58.0.0", "wheel"]
+requires = ["setuptools>=58,<74", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
The `pgserver` build started failing with the setuptools 74.0 release. This fixes the build dependency versions to prevent such regressions.