### PR TITLE
feat: add pgvectorscale extension support for StreamingDiskANN index

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,9 +27,6 @@ jobs:
           - os: ubuntu-24.04-arm
             cibw-archs: aarch64
             deployment-target: ''
-          - os: windows-2022
-            cibw-archs: 'AMD64 ARM64'
-            deployment-target: ''
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
@@ -40,7 +37,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --upgrade cibuildwheel
       - name: Restore postgres build from cache
-        if: ${{ !startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ contains(matrix.os, 'macos') }}
         id: restore-postgres
         uses: actions/cache/restore@v3
         env:
@@ -52,14 +49,14 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.cache-name }}-${{
             hashFiles('Makefile', 'pgbuild/Makefile', '.github/workflows/build-and-test.yml') }}
       - name: Build postgres and pgvector
-        if: ${{ !startsWith(matrix.os, 'ubuntu') && !steps.restore-postgres.outputs.cache-hit }}
+        if: ${{ contains(matrix.os, 'macos') && !steps.restore-postgres.outputs.cache-hit }}
         # Run `make` now so that we may cache the postgres build before running cibuildwheel
         # (On Linux cibuildwheel runs in a docker container, so this won't work)
         env:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment-target }}
         run: make
       - name: Save postgres build
-        if: ${{ !startsWith(matrix.os, 'ubuntu') && !steps.restore-postgres.outputs.cache-hit }}
+        if: ${{ contains(matrix.os, 'macos') && !steps.restore-postgres.outputs.cache-hit }}
         id: cache-postgres
         uses: actions/cache/save@v3
         env:

--- a/pgbuild/Makefile
+++ b/pgbuild/Makefile
@@ -4,7 +4,7 @@ INSTALL_PREFIX := $(shell pwd)/$(INSTALL_RELPATH)
 BUILD := $(shell pwd)/pgbuild/
 
 .PHONY: all
-all: pgvector postgres
+all: pgvector pgvectorscale postgres
 
 ### postgres
 POSTGRES_VERSION := 16.10
@@ -67,6 +67,46 @@ $(INSTALL_PREFIX)/lib/vector.so: $(PGVECTOR_DIR)/Makefile $(INSTALL_PREFIX)/bin/
 .PHONY: pgvector
 pgvector: postgres $(INSTALL_PREFIX)/lib/vector.so
 
+### pgvectorscale (Rust-based extension using pgrx)
+# Requires: Rust toolchain (rustup), cargo
+# Note: Building on macOS x86 (Intel) is not supported upstream
+PGVECTORSCALE_TAG := 0.9.0
+PGVECTORSCALE_URL := https://github.com/timescale/pgvectorscale/archive/refs/tags/$(PGVECTORSCALE_TAG).tar.gz
+PGVECTORSCALE_DIR := pgvectorscale-$(PGVECTORSCALE_TAG)
+
+# Detect if we're on macOS x86 (Intel) where pgvectorscale is not supported
+UNAME_S := $(shell uname -s)
+UNAME_M := $(shell uname -m)
+IS_MACOS_X86 := $(shell [ "$(UNAME_S)" = "Darwin" ] && [ "$(UNAME_M)" = "x86_64" ] && echo "yes" || echo "no")
+
+$(PGVECTORSCALE_DIR).tar.gz:
+	curl -L -o $(PGVECTORSCALE_DIR).tar.gz $(PGVECTORSCALE_URL)
+
+$(PGVECTORSCALE_DIR)/pgvectorscale/Cargo.toml: $(PGVECTORSCALE_DIR).tar.gz
+	mkdir -p $(PGVECTORSCALE_DIR)
+	tar xzf $(PGVECTORSCALE_DIR).tar.gz -C $(PGVECTORSCALE_DIR) --strip-components=1
+	touch $(PGVECTORSCALE_DIR)/pgvectorscale/Cargo.toml
+
+# Build pgvectorscale using cargo-pgrx
+# The extension source is in the pgvectorscale/pgvectorscale subdirectory
+# Skip on macOS x86 (Intel) as it's not supported upstream
+$(INSTALL_PREFIX)/lib/vectorscale.so: $(PGVECTORSCALE_DIR)/pgvectorscale/Cargo.toml $(INSTALL_PREFIX)/bin/postgres pgvector
+ifeq ($(IS_MACOS_X86),yes)
+	@echo "WARNING: Skipping pgvectorscale build on macOS x86 (Intel) - not supported upstream"
+	@echo "See: https://github.com/timescale/pgvectorscale/issues/155"
+else
+	@echo "Building pgvectorscale with Rust/pgrx..."
+	@command -v cargo >/dev/null 2>&1 || { echo "Error: Rust/cargo not found. Install via: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"; exit 1; }
+	cd $(PGVECTORSCALE_DIR)/pgvectorscale && \
+		PGRX_VERSION=$$(cargo metadata --format-version 1 2>/dev/null | jq -r '.packages[] | select(.name == "pgrx") | .version') && \
+		cargo install --locked cargo-pgrx --version $$PGRX_VERSION && \
+		cargo pgrx init --pg16 $(INSTALL_PREFIX)/bin/pg_config && \
+		cargo pgrx install --pg-config $(INSTALL_PREFIX)/bin/pg_config --release
+endif
+
+.PHONY: pgvectorscale
+pgvectorscale: pgvector $(INSTALL_PREFIX)/lib/vectorscale.so
+
 ### other
 .PHONY: clean clean-all
 clean:
@@ -74,6 +114,7 @@ clean:
 	rm -rf $(POSTGRES_SRC)
 	rm -rf $(POSTGRES_BLD)
 	rm -rf $(PGVECTOR_DIR)
+	rm -rf $(PGVECTORSCALE_DIR)
 
 clean-all: clean
 	rm -rf *.tar.gz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pixeltable-pgserver"
-version = "0.4.0"
+version = "0.5.0"
 description = "Embedded Postgres Server for Pixeltable"
 authors = [{ name = "Pixeltable, Inc.", email = "contact@pixeltable.com" }]
 requires-python = ">=3.10"
@@ -64,12 +64,20 @@ include = ["pixeltable_pgserver*"]  # package names should match these glob patt
 testpaths = ["tests"]
 
 [tool.cibuildwheel]
-before-all = "make"
+before-all = "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source $HOME/.cargo/env && make"
 test-extras = "test"
 test-command = "bash -x {project}/cibuildwheel_test.bash {project}"
 
 [tool.cibuildwheel.linux]
-before-all = "yum install -y readline-devel; make"
+before-all = "yum install -y readline-devel openssl-devel clang && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source $HOME/.cargo/env && make"
+
+[tool.cibuildwheel.macos]
+# Rust should be available; just source cargo env
+before-all = "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source $HOME/.cargo/env && make"
+
+[tool.cibuildwheel.windows]
+# Windows needs special Rust setup
+before-all = "choco install rust -y && make"
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ test-extras = "test"
 test-command = "bash -x {project}/cibuildwheel_test.bash {project}"
 
 [tool.cibuildwheel.linux]
-before-all = "yum install -y readline-devel openssl-devel clang && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source $HOME/.cargo/env && make"
+before-all = "yum install -y readline-devel openssl-devel zlib-devel bison flex perl gcc gcc-c++ make jq clang && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source $HOME/.cargo/env && make"
 
 [tool.cibuildwheel.macos]
 # Rust should be available; just source cargo env


### PR DESCRIPTION
- Add pgvectorscale v0.9.0 build target to Makefile
- Use cargo-pgrx for Rust-based extension compilation
- Skip build on macOS x86 (Intel) - not supported upstream
- Add Rust toolchain installation to cibuildwheel hooks
- Bump version to 0.5.0

This enables the DiskANN index type which provides:
- 28x lower P95 latency at 50M+ vectors
- Statistical Binary Quantization for efficient storage
- High-performance vector search at scale

Context: https://github.com/timescale/pgvectorscale/edit/main/README.md
Related PR: https://github.com/pixeltable/pixeltable/pull/970
User Request: #Zooo